### PR TITLE
LayerNorm test ONNX model generation fixes

### DIFF
--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -141,6 +141,8 @@ def build_layernorm_graph(
         domain="finn.custom_op.fpgadataflow.hls",
         rhs_shape=scale_bias_shape,
         lhs_shape=idm,
+        rhs_dtype=str(weight_datatype),
+        lhs_dtype=str(input_datatype),
         out_shape=idm,
         name='ElementwiseMul_hls_0',
     )
@@ -155,6 +157,8 @@ def build_layernorm_graph(
         domain="finn.custom_op.fpgadataflow.hls",
         rhs_shape=scale_bias_shape,
         lhs_shape=idm,
+        rhs_dtype=str(bias_datatype),
+        lhs_dtype=str(input_datatype),
         out_shape=idm,
         name='ElementwiseAdd_hls_0',
     )

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -97,7 +97,7 @@ def build_layernorm_graph(
     Quant_LayerNorm_scale = helper.make_node(
             'Quant',
             domain='qonnx.custom_op.general',
-            inputs=["layernorm0_scale_param", 'layernorn_scale_quant_scale', 'layernorm_scale_quant_zeropt', 'layernorm_scale_quant_bitwidth'],
+            inputs=["layernorm0_scale_param", 'layernorm_scale_quant_scale', 'layernorm_scale_quant_zeropt', 'layernorm_scale_quant_bitwidth'],
             outputs=[Quant_LayerNorm_scale_out.name],
             narrow=0,
             signed=1,
@@ -111,7 +111,7 @@ def build_layernorm_graph(
     Quant_LayerNorm_bias = helper.make_node(
             'Quant',
             domain='qonnx.custom_op.general',
-            inputs=["layernorm0_b_param", 'layernorn_bias_quant_scale', 'layernorm_bias_quant_zeropt', 'layernorm_bias_quant_bitwidth'],
+            inputs=["layernorm0_b_param", 'layernorm_bias_quant_scale', 'layernorm_bias_quant_zeropt', 'layernorm_bias_quant_bitwidth'],
             outputs=[Quant_LayerNorm_bias_out.name],
             narrow=0,
             signed=1,
@@ -323,8 +323,8 @@ def test_fpga_dataflow_layernorm(impl_style, simd, idt,  odt, ifm_dim):
     # model = make_single_layernorm_modelwrapper(impl_style, simd, idt, odt, ifm_dim)
     model = build_layernorm_graph(idt,idt,idt,odt,epsilon,ifm_dim)
     
-    # model.save(export_onnx_path_1)
     model = model.transform(InferShapes())
+    model.save(export_onnx_path_1)
 
     if(ifm_dim[-1] % simd != 0):
         pytest.skip(f"Skipping this test because the inner dimension is not a multiple of {simd}")

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -90,7 +90,9 @@ def build_layernorm_graph(
     model.graph.node.append(Quant_0)
     model.graph.value_info.append(Quant_0_out)
 
-    Quant_LayerNorm_scale_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, [last_dim])
+    scale_bias_shape = [last_dim]
+
+    Quant_LayerNorm_scale_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, scale_bias_shape)
     Quant_LayerNorm_scale = helper.make_node(
             'Quant',
             domain='qonnx.custom_op.general',
@@ -104,7 +106,7 @@ def build_layernorm_graph(
     model.graph.node.append(Quant_LayerNorm_scale)
     model.graph.value_info.append(Quant_LayerNorm_scale_out)
 
-    Quant_LayerNorm_bias_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, [last_dim])
+    Quant_LayerNorm_bias_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, scale_bias_shape)
     Quant_LayerNorm_bias = helper.make_node(
             'Quant',
             domain='qonnx.custom_op.general',
@@ -137,6 +139,9 @@ def build_layernorm_graph(
         inputs=[LayerNorm_0_out.name, Quant_LayerNorm_scale_out.name],
         outputs=[ElementWiseMul_hls_0_out.name],
         domain="finn.custom_op.fpgadataflow.hls",
+        rhs_shape=scale_bias_shape,
+        lhs_shape=idm,
+        out_shape=idm,
         name='ElementwiseMul_hls_0',
     )
     model.graph.node.append(ElementWiseMul_hls_0)
@@ -148,6 +153,9 @@ def build_layernorm_graph(
         inputs=[ElementWiseMul_hls_0_out.name, Quant_LayerNorm_bias_out.name],
         outputs=[ElementWiseAdd_hls_0_out.name],
         domain="finn.custom_op.fpgadataflow.hls",
+        rhs_shape=scale_bias_shape,
+        lhs_shape=idm,
+        out_shape=idm,
         name='ElementwiseAdd_hls_0',
     )
     model.graph.node.append(ElementWiseAdd_hls_0)

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 import pytest
 import torch
+import onnx
 import torch.nn as nn
 import brevitas.nn as qnn
 import finn.core.onnx_exec as oxe
@@ -125,7 +126,6 @@ def build_layernorm_graph(
         'LayerNormalization',
         inputs=[Quant_0_out.name, "layernorm0_scale_param", "layernorm0_b_param"],
         outputs=[LayerNorm_0_out.name],
-        domain="ai.onnx v18",
         name='Layernorm_1',
     )
     model.graph.node.append(LayerNorm_0)
@@ -193,8 +193,17 @@ def build_layernorm_graph(
     model.set_initializer("layernorm0_scale_param", np.zeros((last_dim), dtype=np.float32))
     model.set_initializer("layernorm0_b_param", np.zeros((last_dim), dtype=np.float32))
     model.set_initializer("layernorm0_epsilon_param", np.asarray(epsilon, dtype=np.float32))
+
     model.save(export_onnx_path_0)
-    return model
+
+    # Force the opset to 17 (TODO: Must be a better way to do this)
+    _model = onnx.load(export_onnx_path_0)
+    op = onnx.OperatorSetIdProto()
+    op.version = 17
+    _model_opset17 = helper.make_model(_model.graph, opset_imports=[op])    
+    onnx.save(_model_opset17, export_onnx_path_0)
+
+    return ModelWrapper(export_onnx_path_0) 
 
 
 def make_single_layernorm_modelwrapper(impl_style="hls", simd=1, idt=DataType["FLOAT32"], odt=DataType["FLOAT32"], ifm_dim=(128, 384)):

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -79,7 +79,7 @@ def build_layernorm_graph(
     # Create node
     Quant_0 = helper.make_node(
             'Quant',
-            domain='finn.custom_op.general',
+            domain='qonnx.custom_op.general',
             inputs=[inp.name, 'quant0_scale', 'quant0_zeropt', 'quant0_bitwidth'],
             outputs=[Quant_0_out.name],
             narrow=0,
@@ -93,7 +93,7 @@ def build_layernorm_graph(
     Quant_LayerNorm_scale_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, [last_dim])
     Quant_LayerNorm_scale = helper.make_node(
             'Quant',
-            domain='finn.custom_op.general',
+            domain='qonnx.custom_op.general',
             inputs=["layernorm0_scale_param", 'layernorn_scale_quant_scale', 'layernorm_scale_quant_zeropt', 'layernorm_scale_quant_bitwidth'],
             outputs=[Quant_LayerNorm_scale_out.name],
             narrow=0,
@@ -107,7 +107,7 @@ def build_layernorm_graph(
     Quant_LayerNorm_bias_out = helper.make_tensor_value_info(model.make_new_valueinfo_name(), TensorProto.FLOAT, [last_dim])
     Quant_LayerNorm_bias = helper.make_node(
             'Quant',
-            domain='finn.custom_op.general',
+            domain='qonnx.custom_op.general',
             inputs=["layernorm0_b_param", 'layernorn_bias_quant_scale', 'layernorm_bias_quant_zeropt', 'layernorm_bias_quant_bitwidth'],
             outputs=[Quant_LayerNorm_bias_out.name],
             narrow=0,
@@ -156,7 +156,7 @@ def build_layernorm_graph(
     # Create node
     Quant_1 = helper.make_node(
             'Quant',
-            domain='finn.custom_op.general',
+            domain='qonnx.custom_op.general',
             inputs=[ElementWiseAdd_hls_0_out.name, 'quant1_scale', 'quant1_zeropt', 'quant1_bitwidth'],
             outputs=[outp.name],
             narrow=0,


### PR DESCRIPTION
This PR fixes a couple of issues with the ONNX graph generation for the LayerNorm tests.

* Fixes the correct domain for the QONNX Quant nodes
* Adds attributes for the lhs/rhs shape and datatypes for the eltwise nodes
* Forces LayerNormalisation to use the `v17 opset` rather than `v1 experimental`.
* Typo fixing layernorn -> layernorm

I've been thinking a bit about this and I think we might want to move away from the eltwise operators and move to the ONNX Add/Mul operators and instead lower through transformations. I'll get up a separate PR for that though. 