### PR TITLE
Fixing some issues so cppsim can compile

### DIFF
--- a/custom_hls/layernorm/layernorm.hpp
+++ b/custom_hls/layernorm/layernorm.hpp
@@ -167,8 +167,8 @@ template<typename TO, unsigned N, unsigned SIMD>
 void inv_sqrt_stage(
 	const TO epsilon,
 	hls::stream<hls::vector<TO, SIMD>> &in_s,
-	hls::stream<hls::vector<TO, SIMD>> &out_s
-	hls::stream<varmean_t<TO>> &varmean_s,
+	hls::stream<hls::vector<TO, SIMD>> &out_s,
+	hls::stream<varmean_t<TO>> &varmean_s
 ) {
 #pragma HLS pipeline II=1 style=flp
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -251,6 +251,7 @@ if [ ! -z "$FINN_XILINX_PATH" ];then
   fi
   if [ -d "$HLS_PATH" ];then
     DOCKER_EXEC+="-e HLS_PATH=$HLS_PATH "
+    DOCKER_EXEC+="-e LD_LIBRARY_PATH=$HLS_PATH/lnx64/tools/fpo_v7_1 "
   fi
   if [ -d "$VITIS_PATH" ];then
     DOCKER_EXEC+="-e VITIS_PATH=$VITIS_PATH "


### PR DESCRIPTION
This PR contains two fixes for enabling cppsim to compile.
* There were a few syntax errors in the layernorm.hpp in this branch (some of the function args seemed to be swapped)
* We needed to include some floating point shared libraries in the `LD_LIBRARY_PATH` environment variable within the docker to enable the generated executable to run. 