### PR TITLE
[BugFix] RTLSim I/O name issues

### DIFF
--- a/src/finn/custom_op/fpgadataflow/hls/layernorm_hls.py
+++ b/src/finn/custom_op/fpgadataflow/hls/layernorm_hls.py
@@ -31,6 +31,7 @@ import os
 
 import finn.util.pyxsi_rpcclient as pyxsi_rpcclient
 from finn.custom_op.fpgadataflow import templates
+from finn.util.data_packing import npy_to_rtlsim_input, rtlsim_output_to_npy
 from finn.custom_op.fpgadataflow.hlsbackend import HLSBackend
 from finn.custom_op.fpgadataflow.layernorm import LayerNorm
 from finn.util.basic import make_build_dir
@@ -67,24 +68,26 @@ class LayerNorm_hls(LayerNorm, HLSBackend):
     def docompute(self):
         self.code_gen_dict["$DOCOMPUTE$"] = [
             f"""
-                layernorm_pipeline<TI, TO, W, SIMD>(epsilon, src, dst);
+                layernorm_pipeline<TI, TO, W, SIMD>(epsilon, in0_{self.hls_sname()}, out_{self.hls_sname()});
             """
         ]
 
     def blackboxfunction(self):
         self.code_gen_dict["$BLACKBOXFUNCTION$"] = [
-            f"void {self.onnx_node.name}(",
-            f"    hls::stream<hls::vector<TI,SIMD>> &src,",
-            f"    hls::stream<hls::vector<TO,SIMD>> &dst",
-            ")"
+            f"""
+            void {self.onnx_node.name}(
+                hls::stream<hls::vector<TI,SIMD>> &in0_{self.hls_sname()},
+                hls::stream<hls::vector<TO,SIMD>> &out_{self.hls_sname()}
+                )
+            """
         ]
 
     def pragmas(self):
         self.code_gen_dict["$PRAGMAS$"] = [
-            f"#pragma HLS interface AXIS port=src",
-            f"#pragma HLS interface AXIS port=dst",
-            f"#pragma HLS aggregate variable=src compact=bit",
-            f"#pragma HLS aggregate variable=dst compact=bit",
+            f"#pragma HLS interface AXIS port=in0_{self.hls_sname()}",
+            f"#pragma HLS interface AXIS port=out_{self.hls_sname()}",
+            f"#pragma HLS aggregate variable=in0_{self.hls_sname()} compact=bit",
+            f"#pragma HLS aggregate variable=out_{self.hls_sname()} compact=bit",
             f"#pragma HLS interface ap_ctrl_none port=return",
             f"#pragma HLS dataflow disable_start_propagation",
         ]
@@ -102,10 +105,6 @@ class LayerNorm_hls(LayerNorm, HLSBackend):
         # # Select and execute the function by mode string
         # exec_fns[mode](context, graph)
 
-
-
-        
-        
         node = self.onnx_node
         exp_ishape = self.get_normal_input_shape()
         exp_oshape = self.get_normal_output_shape()

--- a/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
+++ b/src/finn/transformation/fpgadataflow/convert_to_hw_layers.py
@@ -2173,6 +2173,7 @@ class InferLayerNorm(Transformation):
                     epsilon=helper.get_node_attr_value(node, "epsilon"),
                     inputDataType=idt.name,
                     outputDataType=odt.name,
+                    rtlsim_backend="pyxsi",
                     name="LayerNorm_" + node.name,
                 )
                 graph.node.insert(insert_point, new_node)


### PR DESCRIPTION
Small fix that adjusts the codegen of the top level HLS module so that it matches the naming convention for HLS operators.

Sorry, I think I might have mislead you before that HLS nodes did not have the same signal naming constraints as RTL nodes, but it turns out that they do. This PR should fix it. 